### PR TITLE
Fixes I made for Issues #1 and #2 that I entered.

### DIFF
--- a/source/Indiefreaks.Game.UI/Rendering/Gui/Control.cs
+++ b/source/Indiefreaks.Game.UI/Rendering/Gui/Control.cs
@@ -35,13 +35,13 @@ namespace Indiefreaks.Xna.Rendering.Gui
         /// Gets or sets the scale factor to be applied to this control
         /// </summary>
         public Vector2 Scale { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the rotation angle (in radians) of the control
         /// </summary>
         public float Rotation
         {
-            get { return _rotation;}
+            get { return _rotation; }
             set
             {
                 if (_rotation != value)
@@ -129,7 +129,7 @@ namespace Indiefreaks.Xna.Rendering.Gui
         /// </summary>
         public void LoseFocus()
         {
-            if(HasFocus)
+            if (HasFocus)
                 OnFocusLost();
         }
 
@@ -144,7 +144,7 @@ namespace Indiefreaks.Xna.Rendering.Gui
             {
                 GraphicsDevice device = spriteRenderer.GraphicsDevice;
                 // we refresh the control properties
-                ((IGuiElement) this).Refresh(device);
+                ((IGuiElement)this).Refresh(device);
 
                 device.SetRenderTarget(_renderTarget2D);
                 device.Clear(Color.Transparent);
@@ -298,7 +298,19 @@ namespace Indiefreaks.Xna.Rendering.Gui
             var width = Math.Min(Width, 4096);
             var height = Math.Min(Height, 4096);
 #endif
-            _renderTarget2D = new RenderTarget2D(device, Math.Max(width, 1), Math.Max(height,1), useMipMap, SurfaceFormat.Color, DepthFormat.None, Application.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount, RenderTargetUsage.PreserveContents);
+            if (_renderTarget2D != null && (width != _renderTarget2D.Width || height != _renderTarget2D.Height))
+            {
+                _renderTarget2D.Dispose();
+                _renderTarget2D = null;
+            }
+
+            if (_renderTarget2D == null)
+            {
+                _renderTarget2D = new RenderTarget2D(device, Math.Max(width, 1), Math.Max(height, 1), useMipMap, SurfaceFormat.Color,
+                                                     DepthFormat.None,
+                                                     Application.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount,
+                                                     RenderTargetUsage.PreserveContents);
+            }
         }
 
         /// <summary>

--- a/source/Indiefreaks.Game.UI/Rendering/Gui/Screen.cs
+++ b/source/Indiefreaks.Game.UI/Rendering/Gui/Screen.cs
@@ -68,7 +68,7 @@ namespace Indiefreaks.Xna.Rendering.Gui
                     foreach (Control control in _controls)
                     {
                         if (control.IsVisible)
-                        ((IGuiElement)control).Invalidate();
+                            ((IGuiElement)control).Invalidate();
                     }
             };
 
@@ -339,10 +339,23 @@ namespace Indiefreaks.Xna.Rendering.Gui
 #else
             const bool useMipMap = true;
 #endif
-            if (Width == 0 || Height == 0)
-                _renderTarget2D = new RenderTarget2D(device, 100, 100, useMipMap, SurfaceFormat.Color, DepthFormat.None, Application.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount, RenderTargetUsage.PreserveContents);
-            else
-                _renderTarget2D = new RenderTarget2D(device, Width, Height, useMipMap, SurfaceFormat.Color, DepthFormat.None, Application.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount, RenderTargetUsage.PreserveContents);
+            if (_renderTarget2D != null && (Width != _renderTarget2D.Width || Height != _renderTarget2D.Height))
+            {
+                _renderTarget2D.Dispose();
+                _renderTarget2D = null;
+            }
+
+            if (_renderTarget2D == null)
+            {
+                if (Width == 0 || Height == 0)
+                    _renderTarget2D = new RenderTarget2D(device, 100, 100, useMipMap, SurfaceFormat.Color, DepthFormat.None,
+                                                         Application.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount,
+                                                         RenderTargetUsage.PreserveContents);
+                else
+                    _renderTarget2D = new RenderTarget2D(device, Width, Height, useMipMap, SurfaceFormat.Color, DepthFormat.None,
+                                                         Application.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount,
+                                                         RenderTargetUsage.PreserveContents);
+            }
         }
 
         /// <summary>
@@ -379,6 +392,7 @@ namespace Indiefreaks.Xna.Rendering.Gui
         {
             _controls.Clear();
             _focusableControls.Clear();
+            _focusedControlIndex = 0;
         }
 
         #region Implementation of IUpdate


### PR DESCRIPTION
FIX: #2 Screen.RemoveAll() does not reset _focusedControlIndex - _focusedControlIndex is not set to 0 in Screen.RemoveAll.
FIX: #1 Memory leak in Screen and Control PrepareRenderTarget - PrepareRenderTarget will now check if the rendertarget needs to
be disposed and recreated. It will only be recreated if it's width and height has changed.

These fixes have only been tested in my app but I wanted to share them with you for your consideration.
